### PR TITLE
Release 1.1.0: Validate Query Parameters

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    next_page (1.0.0)
+    next_page (1.1.0)
       activerecord (>= 7.2)
 
 GEM

--- a/lib/next_page/version.rb
+++ b/lib/next_page/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module NextPage
-  VERSION = '1.0.0'.freeze
+  VERSION = '1.1.0'.freeze
 end


### PR DESCRIPTION
Query params for the page size and number are now validated to handle invalid, nonesensical, or malicious values that might cause long-running queries.

This release also updates the minimum required versions:

- Ruby: 3.2
- Rails: 7.2